### PR TITLE
Combine duplicate lies in voting

### DIFF
--- a/src/services/QuestionService.js
+++ b/src/services/QuestionService.js
@@ -201,11 +201,14 @@ class QuestionService {
    * @returns {Array} Shuffled array with position tracking
    */
   shuffleOptions(options) {
-    const shuffled = options.map((option, originalIndex) => ({
-      text: option,
-      originalIndex,
-      id: Math.random().toString(36).substr(2, 9) // Unique ID for frontend
-    }));
+    const shuffled = options.map((option, originalIndex) => {
+      const opt = typeof option === 'string' ? { text: option } : { ...option };
+      return {
+        ...opt,
+        originalIndex,
+        id: Math.random().toString(36).substr(2, 9) // Unique ID for frontend
+      };
+    });
     
     // Fisher-Yates shuffle
     for (let i = shuffled.length - 1; i > 0; i--) {


### PR DESCRIPTION
## Summary
- combine duplicate lies into one voting option
- pad missing lies with random choices from the question's suggestion list
- allow `shuffleOptions` to accept full option objects

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684dbf193b5883309f355793acc7eecc