### PR TITLE
Avoid duplicate questions and category duplicates

### DIFF
--- a/src/services/QuestionService.js
+++ b/src/services/QuestionService.js
@@ -214,12 +214,15 @@ class QuestionService {
    * @param {Object} question - The question object
    * @returns {string} A random lie
    */
-  getRandomLieFromQuestion(question) {
+  getRandomLieFromQuestion(question, usedLies = new Set()) {
     if (!question.lies || question.lies.length === 0) {
       return "Mystery answer"; // Fallback
     }
-    
-    return question.lies[Math.floor(Math.random() * question.lies.length)];
+
+    const available = question.lies.filter(l => !usedLies.has(l));
+    const pool = available.length > 0 ? available : question.lies;
+
+    return pool[Math.floor(Math.random() * pool.length)];
   }
 
   /**


### PR DESCRIPTION
## Summary
- avoid reusing a question once it's been asked
- ensure the four category options have unique categories when possible
- track asked questions and clear them between games

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc3fcaecc8330b5b5de20c51474c8