### PR TITLE
Add host/player HTML pages with socket.io

### DIFF
--- a/public/host.html
+++ b/public/host.html
@@ -111,7 +111,7 @@ function log(msg){ document.getElementById('log').textContent += msg+'\n'; }
 
 socket.on('connect', () => { socket.emit('request_game_state'); });
 socket.on('game_state_update', d => { gameState = d; render(); });
-socket.on('sub_step_info', d => { subStep = d; render(); });
+socket.on('host_sub_step_info', d => { subStep = d; render(); });
 socket.on('timer_update', d => { document.getElementById('timer').textContent = '⏱ '+d.secondsRemaining+'s'; });
 socket.on('truth_reveal_start', d => renderReveal(d));
 socket.on('scoreboard_update', d => renderScoreboard(d));

--- a/public/host.html
+++ b/public/host.html
@@ -6,62 +6,148 @@
   <script src="/socket.io/socket.io.js"></script>
   <style>
     body { font-family: sans-serif; padding: 20px; }
-    #log { background:#eee; padding:10px; white-space:pre-line; }
+    .view { display: none; margin: 20px 0; }
+    #log { background:#eee; padding:10px; white-space:pre-line; max-height: 200px; overflow:auto; }
+    ul { list-style: none; padding: 0; }
+    table { border-collapse: collapse; }
+    td, th { border: 1px solid #ccc; padding: 4px 8px; }
   </style>
 </head>
 <body>
   <h1>Lie-Ability - Host Screen</h1>
-  <div id="status">Connecting...</div>
-  <div id="phase"></div>
-  <div id="question"></div>
-  <div id="options"></div>
   <div id="timer"></div>
+
+  <div id="lobbyView" class="view">Waiting for players...</div>
+  <div id="categoryView" class="view">
+    <h3 id="categoryPrompt"></h3>
+    <ul id="categoryList"></ul>
+  </div>
+  <div id="questionView" class="view">
+    <h3 id="questionText"></h3>
+  </div>
+  <div id="lieView" class="view">Players are submitting lies...</div>
+  <div id="optionView" class="view">
+    <ul id="optionList"></ul>
+  </div>
+  <div id="revealView" class="view">
+    <h3 id="revealQuestion"></h3>
+    <ul id="revealList"></ul>
+  </div>
+  <div id="scoreboardView" class="view">
+    <table id="scoreTable"></table>
+  </div>
+
   <pre id="log"></pre>
 
 <script>
 const socket = io();
-const logEl = document.getElementById('log');
-const phaseEl = document.getElementById('phase');
-const questionEl = document.getElementById('question');
-const optionsEl = document.getElementById('options');
-const timerEl = document.getElementById('timer');
-const statusEl = document.getElementById('status');
+let gameState = null;
+let subStep = null;
+const sections = {
+  lobby: document.getElementById('lobbyView'),
+  category: document.getElementById('categoryView'),
+  question: document.getElementById('questionView'),
+  lie: document.getElementById('lieView'),
+  option: document.getElementById('optionView'),
+  reveal: document.getElementById('revealView'),
+  score: document.getElementById('scoreboardView')
+};
 
-function log(msg){ logEl.textContent += msg + '\n'; }
+function hideAll(){ Object.values(sections).forEach(s => s.style.display='none'); }
+function show(name){ hideAll(); if(sections[name]) sections[name].style.display='block'; }
+function log(msg){ document.getElementById('log').textContent += msg+'\n'; }
 
-socket.on('connect', () => {
-  statusEl.textContent = 'Connected';
-  socket.emit('request_game_state');
-});
+socket.on('connect', () => { socket.emit('request_game_state'); });
+socket.on('game_state_update', d => { gameState = d; render(); });
+socket.on('sub_step_info', d => { subStep = d; render(); });
+socket.on('timer_update', d => { document.getElementById('timer').textContent = '⏱ '+d.secondsRemaining+'s'; });
+socket.on('truth_reveal_start', d => renderReveal(d));
+socket.on('scoreboard_update', d => renderScoreboard(d));
 
-socket.on('game_state_update', data => {
-  updateState(data);
-});
-
-socket.on('sub_step_info', info => {
-  updateSubStep(info);
-});
-
-socket.on('timer_update', data => {
-  timerEl.textContent = '⏱ ' + data.secondsRemaining + 's';
-});
-
-function updateState(data){
-  phaseEl.textContent = 'Phase: ' + data.state;
-  if(data.currentQuestionData){
-    questionEl.textContent = data.currentQuestionData.category + ': ' + data.currentQuestionData.question;
-  } else {
-    questionEl.textContent = '';
+function render(){
+  if(!gameState) return;
+  log('State -> ' + gameState.state);
+  switch(gameState.state){
+    case 'lobby':
+      show('lobby');
+      break;
+    case 'category_selection':
+      show('category');
+      renderCategory();
+      break;
+    case 'question_reading':
+      show('question');
+      renderQuestion();
+      break;
+    case 'lie_submission':
+      show('lie');
+      break;
+    case 'option_selection':
+      show('option');
+      renderOptions();
+      break;
+    case 'truth_reveal':
+      // handled by reveal event
+      break;
+    case 'scoreboard':
+    case 'game_ended':
+      // scoreboard event will show table
+      break;
   }
-  log('Game state -> ' + data.state);
 }
 
-function updateSubStep(info){
-  if(info.options){
-    optionsEl.innerHTML = info.options.map(o => '<div>' + o.text + '</div>').join('');
-  } else {
-    optionsEl.innerHTML = '';
-  }
+function renderCategory(){
+  if(!subStep) return;
+  const list=document.getElementById('categoryList');
+  list.innerHTML='';
+  (subStep.categories||[]).forEach(c => {
+    const li=document.createElement('li');
+    li.textContent = c.category;
+    list.appendChild(li);
+  });
+  const selectorName = gameState.players.find(p=>p.id===gameState.categorySelector)?.name || '';
+  document.getElementById('categoryPrompt').textContent = subStep.isSelector ? 'You choose the category' : `Waiting for ${selectorName} to pick`;
+}
+
+function renderQuestion(){
+  const q = subStep && subStep.question ? subStep.question : gameState.currentQuestionData;
+  document.getElementById('questionText').textContent = q ? `${q.category}: ${q.question}` : '';
+}
+
+function renderOptions(){
+  const list=document.getElementById('optionList');
+  list.innerHTML='';
+  (subStep?.options||[]).forEach(o => {
+    const li=document.createElement('li');
+    li.textContent = o.text;
+    list.appendChild(li);
+  });
+}
+
+function renderReveal(data){
+  show('reveal');
+  document.getElementById('revealQuestion').textContent = data.question;
+  const list=document.getElementById('revealList');
+  list.innerHTML='';
+  data.lies.forEach(l => {
+    const li=document.createElement('li');
+    li.textContent = `${l.lie} - ${l.voteCount} vote(s)`;
+    list.appendChild(li);
+  });
+  const truth=document.createElement('li');
+  truth.textContent = `Truth: ${data.truth.answer} - ${data.truth.voteCount} correct`;
+  list.appendChild(truth);
+}
+
+function renderScoreboard(data){
+  show('score');
+  const table=document.getElementById('scoreTable');
+  table.innerHTML='<tr><th>Rank</th><th>Name</th><th>Pts</th></tr>';
+  data.players.forEach(p => {
+    const row=document.createElement('tr');
+    row.innerHTML = `<td>${p.rank}</td><td>${p.name}</td><td>${p.points}</td>`;
+    table.appendChild(row);
+  });
 }
 </script>
 </body>

--- a/public/host.html
+++ b/public/host.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Lie-Ability - Host</title>
   <script src="/socket.io/socket.io.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.0/build/qrcode.min.js"></script>
   <style>
     body { font-family: sans-serif; padding: 20px; }
     .view { display: none; margin: 20px 0; }
@@ -11,13 +12,23 @@
     ul { list-style: none; padding: 0; }
     table { border-collapse: collapse; }
     td, th { border: 1px solid #ccc; padding: 4px 8px; }
+    #lobbyContainer { display:flex; gap:20px; align-items:flex-start; }
+    #qrCode canvas { width:200px; height:200px; }
+    #playerList { list-style:none; padding:0; }
+    .player-item { display:flex; align-items:center; margin:5px 0; }
+    .player-avatar { width:32px; height:32px; border-radius:4px; display:flex; align-items:center; justify-content:center; margin-right:8px; font-size:20px; color:#fff; }
   </style>
 </head>
 <body>
   <h1>Lie-Ability - Host Screen</h1>
   <div id="timer"></div>
 
-  <div id="lobbyView" class="view">Waiting for players...</div>
+  <div id="lobbyView" class="view">
+    <div id="lobbyContainer">
+      <div id="qrCode"></div>
+      <ul id="playerList"></ul>
+    </div>
+  </div>
   <div id="categoryView" class="view">
     <h3 id="categoryPrompt"></h3>
     <ul id="categoryList"></ul>
@@ -53,6 +64,43 @@ const sections = {
   score: document.getElementById('scoreboardView')
 };
 
+function generateQRCode(){
+  const url = window.location.origin + '/player';
+  const container = document.getElementById('qrCode');
+  if(!container) return;
+  container.innerHTML = '';
+  if(window.QRCode){
+    const canvas = document.createElement('canvas');
+    QRCode.toCanvas(canvas, url, { width: 200 }, err => {
+      if(!err) container.appendChild(canvas);
+    });
+  } else {
+    const img=document.createElement('img');
+    img.src = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(url)}`;
+    container.appendChild(img);
+  }
+}
+
+function renderLobby(){
+  generateQRCode();
+  const list=document.getElementById('playerList');
+  if(!list) return;
+  list.innerHTML='';
+  (gameState.players||[]).forEach(p=>{
+    const li=document.createElement('li');
+    li.className='player-item';
+    const av=document.createElement('span');
+    av.className='player-avatar';
+    av.textContent=p.avatar.emoji;
+    av.style.backgroundColor=p.avatar.color;
+    li.appendChild(av);
+    const name=document.createElement('span');
+    name.textContent=p.name;
+    li.appendChild(name);
+    list.appendChild(li);
+  });
+}
+
 function hideAll(){ Object.values(sections).forEach(s => s.style.display='none'); }
 function show(name){ hideAll(); if(sections[name]) sections[name].style.display='block'; }
 function log(msg){ document.getElementById('log').textContent += msg+'\n'; }
@@ -70,6 +118,7 @@ function render(){
   switch(gameState.state){
     case 'lobby':
       show('lobby');
+      renderLobby();
       break;
     case 'category_selection':
       show('category');

--- a/public/host.html
+++ b/public/host.html
@@ -28,6 +28,7 @@
       <div id="qrCode"></div>
       <ul id="playerList"></ul>
     </div>
+    <button id="startBtn" disabled>Start Game</button>
   </div>
   <div id="categoryView" class="view">
     <h3 id="categoryPrompt"></h3>
@@ -63,6 +64,8 @@ const sections = {
   reveal: document.getElementById('revealView'),
   score: document.getElementById('scoreboardView')
 };
+const startBtn = document.getElementById('startBtn');
+startBtn.onclick = () => socket.emit('start_game');
 
 function generateQRCode(){
   const url = window.location.origin + '/player';
@@ -99,6 +102,7 @@ function renderLobby(){
     li.appendChild(name);
     list.appendChild(li);
   });
+  startBtn.disabled = (gameState.players||[]).length < 2;
 }
 
 function hideAll(){ Object.values(sections).forEach(s => s.style.display='none'); }
@@ -111,6 +115,8 @@ socket.on('sub_step_info', d => { subStep = d; render(); });
 socket.on('timer_update', d => { document.getElementById('timer').textContent = '⏱ '+d.secondsRemaining+'s'; });
 socket.on('truth_reveal_start', d => renderReveal(d));
 socket.on('scoreboard_update', d => renderScoreboard(d));
+socket.on('player_joined', () => socket.emit('request_game_state'));
+socket.on('player_left', () => socket.emit('request_game_state'));
 
 function render(){
   if(!gameState) return;

--- a/public/host.html
+++ b/public/host.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Lie-Ability - Host</title>
+  <script src="/socket.io/socket.io.js"></script>
+  <style>
+    body { font-family: sans-serif; padding: 20px; }
+    #log { background:#eee; padding:10px; white-space:pre-line; }
+  </style>
+</head>
+<body>
+  <h1>Lie-Ability - Host Screen</h1>
+  <div id="status">Connecting...</div>
+  <div id="phase"></div>
+  <div id="question"></div>
+  <div id="options"></div>
+  <div id="timer"></div>
+  <pre id="log"></pre>
+
+<script>
+const socket = io();
+const logEl = document.getElementById('log');
+const phaseEl = document.getElementById('phase');
+const questionEl = document.getElementById('question');
+const optionsEl = document.getElementById('options');
+const timerEl = document.getElementById('timer');
+const statusEl = document.getElementById('status');
+
+function log(msg){ logEl.textContent += msg + '\n'; }
+
+socket.on('connect', () => {
+  statusEl.textContent = 'Connected';
+  socket.emit('request_game_state');
+});
+
+socket.on('game_state_update', data => {
+  updateState(data);
+});
+
+socket.on('sub_step_info', info => {
+  updateSubStep(info);
+});
+
+socket.on('timer_update', data => {
+  timerEl.textContent = '⏱ ' + data.secondsRemaining + 's';
+});
+
+function updateState(data){
+  phaseEl.textContent = 'Phase: ' + data.state;
+  if(data.currentQuestionData){
+    questionEl.textContent = data.currentQuestionData.category + ': ' + data.currentQuestionData.question;
+  } else {
+    questionEl.textContent = '';
+  }
+  log('Game state -> ' + data.state);
+}
+
+function updateSubStep(info){
+  if(info.options){
+    optionsEl.innerHTML = info.options.map(o => '<div>' + o.text + '</div>').join('');
+  } else {
+    optionsEl.innerHTML = '';
+  }
+}
+</script>
+</body>
+</html>

--- a/public/host.html
+++ b/public/host.html
@@ -117,6 +117,7 @@ socket.on('truth_reveal_start', d => renderReveal(d));
 socket.on('scoreboard_update', d => renderScoreboard(d));
 socket.on('player_joined', () => socket.emit('request_game_state'));
 socket.on('player_left', () => socket.emit('request_game_state'));
+socket.on('player_avatar_updated', () => socket.emit('request_game_state'));
 
 function render(){
   if(!gameState) return;

--- a/public/player.html
+++ b/public/player.html
@@ -6,7 +6,10 @@
   <script src="/socket.io/socket.io.js"></script>
   <style>
     body{font-family:sans-serif;padding:20px;}
+    .view{display:none;margin:20px 0;}
     #options button{display:block;margin:5px 0;}
+    table{border-collapse:collapse;}
+    td,th{border:1px solid #ccc;padding:4px 8px;}
   </style>
 </head>
 <body>
@@ -16,129 +19,190 @@
     <input id="nameInput" placeholder="Name">
     <button id="joinBtn">Join</button>
   </div>
-  <div id="game" style="display:none;">
-    <div id="phase"></div>
-    <div id="question"></div>
-    <div id="lieSection" style="display:none;">
+
+  <div id="views" style="display:none;">
+    <div id="lobbyView" class="view">Waiting for game start...</div>
+    <div id="categoryView" class="view">
+      <h3 id="categoryPrompt"></h3>
+      <div id="categoryButtons"></div>
+    </div>
+    <div id="questionView" class="view">
+      <div id="questionText"></div>
+    </div>
+    <div id="lieView" class="view">
       <input id="lieInput" placeholder="Enter your lie">
       <button id="autoLie">Auto Lie</button>
       <button id="submitLie">Submit</button>
       <div id="lieStatus"></div>
     </div>
-    <div id="options" style="display:none;"></div>
-    <div id="voteStatus"></div>
-    <div id="likeSection" style="display:none;">
-      <button id="likeBtn">Like Selected Lie</button>
+    <div id="voteView" class="view">
+      <div id="options"></div>
+      <div id="voteStatus"></div>
+      <button id="likeBtn" style="display:none;">Like Selected Lie</button>
+    </div>
+    <div id="revealView" class="view">
+      <div id="revealQuestion"></div>
+      <ul id="revealList"></ul>
+    </div>
+    <div id="scoreboardView" class="view">
+      <table id="scoreTable"></table>
     </div>
     <div id="timer"></div>
   </div>
+
   <pre id="log"></pre>
 
 <script>
 const socket = io();
 let playerId = null;
-let currentOptions = [];
+let gameState = null;
+let subStep = null;
 let selectedOption = null;
 
-function log(msg){document.getElementById('log').textContent += msg+'\n';}
+const views = {
+  lobby: document.getElementById('lobbyView'),
+  category: document.getElementById('categoryView'),
+  question: document.getElementById('questionView'),
+  lie: document.getElementById('lieView'),
+  vote: document.getElementById('voteView'),
+  reveal: document.getElementById('revealView'),
+  score: document.getElementById('scoreboardView')
+};
 
-socket.on('connect', ()=>{
-  document.getElementById('connection').textContent = 'Connected';
-});
+function hideAll(){ Object.values(views).forEach(v=>v.style.display='none'); }
+function show(name){ hideAll(); if(views[name]) views[name].style.display='block'; }
+function log(msg){ document.getElementById('log').textContent+=msg+'\n'; }
 
+socket.on('connect', () => { document.getElementById('connection').textContent = 'Connected'; });
 socket.on('player_joined', data => {
   if(!playerId && data.player){
     playerId = data.player.id;
     document.getElementById('joinSection').style.display='none';
-    document.getElementById('game').style.display='block';
-  }
-  log(`${data.player.name} joined`);
-});
-
-socket.on('player_reconnected', d=>{
-  if(d.playerId === playerId){
-    socket.emit('request_game_state');
+    document.getElementById('views').style.display='block';
   }
 });
-
-socket.on('game_state_update', data => { updateGame(data); });
-socket.on('sub_step_info', info => { updateSubStep(info); });
-
-socket.on('lie_submitted', ()=>{
-  document.getElementById('lieStatus').textContent='Lie submitted!';
-});
-
-socket.on('option_selected', ()=>{
-  document.getElementById('voteStatus').textContent='Vote submitted!';
-});
-
-socket.on('timer_update', data => {
-  document.getElementById('timer').textContent='⏱ '+data.secondsRemaining+'s';
-});
-
-socket.on('lie_liked', ()=>{
-  document.getElementById('likeSection').style.display='none';
-});
-
-socket.on('error', data => { log('Error: '+data.message); });
+socket.on('player_reconnected', d => { if(d.playerId === playerId) socket.emit('request_game_state'); });
+socket.on('game_state_update', d => { gameState=d; render(); });
+socket.on('sub_step_info', d => { subStep=d; render(); });
+socket.on('timer_update', d => { document.getElementById('timer').textContent='⏱ '+d.secondsRemaining+'s'; });
+socket.on('lie_submitted', () => { document.getElementById('lieStatus').textContent='Lie submitted!'; });
+socket.on('option_selected', () => { document.getElementById('voteStatus').textContent='Vote submitted!'; });
+socket.on('truth_reveal_start', d => renderReveal(d));
+socket.on('scoreboard_update', d => renderScoreboard(d));
+socket.on('lie_liked', () => { document.getElementById('likeBtn').style.display='none'; });
+socket.on('error', data => log('Error: '+data.message));
 
 document.getElementById('joinBtn').onclick = () => {
-  const name = document.getElementById('nameInput').value.trim();
-  if(name){
-    socket.emit('join_game',{playerName:name});
-  }
+  const name=document.getElementById('nameInput').value.trim();
+  if(name){ socket.emit('join_game',{playerName:name}); }
 };
 
 document.getElementById('submitLie').onclick = () => {
-  const lie = document.getElementById('lieInput').value.trim();
-  if(lie){
-    socket.emit('submit_lie',{lie});
-  }
+  const lie=document.getElementById('lieInput').value.trim();
+  if(lie){ socket.emit('submit_lie',{lie}); }
 };
 
 document.getElementById('autoLie').onclick = () => { socket.emit('auto_lie'); };
-
-function updateGame(data){
-  document.getElementById('phase').textContent='Phase: '+data.state;
-  if(data.currentQuestionData){
-    document.getElementById('question').textContent=data.currentQuestionData.question;
-  }
-}
-
-function updateSubStep(info){
-  if(info.state==='lie_submission'){
-    document.getElementById('lieSection').style.display='block';
-  }else{
-    document.getElementById('lieSection').style.display='none';
-  }
-
-  if(info.state==='option_selection' && info.options){
-    currentOptions = info.options;
-    const container = document.getElementById('options');
-    container.innerHTML='';
-    info.options.forEach(opt=>{
-      const btn=document.createElement('button');
-      btn.textContent=opt.text;
-      btn.onclick=()=>{
-        selectedOption=opt;
-        socket.emit('select_option',{optionId:opt.id});
-        document.getElementById('voteStatus').textContent='Voted for '+opt.text;
-      };
-      container.appendChild(btn);
-    });
-    container.style.display='block';
-    document.getElementById('likeSection').style.display='block';
-  }else{
-    document.getElementById('options').style.display='none';
-    document.getElementById('likeSection').style.display='none';
-  }
-}
 
 document.getElementById('likeBtn').onclick = () => {
   if(selectedOption && selectedOption.submittedById){
     socket.emit('like_lie',{likedPlayerId:selectedOption.submittedById});
   }
 };
+
+function render(){
+  if(!gameState) return;
+  switch(gameState.state){
+    case 'lobby':
+      show('lobby');
+      break;
+    case 'category_selection':
+      show('category');
+      renderCategory();
+      break;
+    case 'question_reading':
+      show('question');
+      renderQuestion();
+      break;
+    case 'lie_submission':
+      show('lie');
+      break;
+    case 'option_selection':
+      show('vote');
+      renderOptions();
+      break;
+    case 'truth_reveal':
+      break;
+    case 'scoreboard':
+    case 'game_ended':
+      break;
+  }
+}
+
+function renderCategory(){
+  const container=document.getElementById('categoryButtons');
+  container.innerHTML='';
+  if(subStep?.categories){
+    subStep.categories.forEach(c => {
+      const btn=document.createElement('button');
+      btn.textContent=c.category;
+      if(subStep.isSelector){
+        btn.onclick=()=>{ socket.emit('select_category',{categoryId:c.id}); };
+      }
+      container.appendChild(btn);
+    });
+  }
+  const selectorName=gameState.players.find(p=>p.id===gameState.categorySelector)?.name || '';
+  document.getElementById('categoryPrompt').textContent=subStep.isSelector ? 'Choose a category' : `Waiting for ${selectorName}`;
+}
+
+function renderQuestion(){
+  const q=subStep?.question || gameState.currentQuestionData;
+  document.getElementById('questionText').textContent = q ? `${q.category}: ${q.question}` : '';
+}
+
+function renderOptions(){
+  const container=document.getElementById('options');
+  container.innerHTML='';
+  if(subStep?.options){
+    subStep.options.forEach(opt => {
+      const btn=document.createElement('button');
+      btn.textContent=opt.text;
+      btn.onclick=()=>{
+        selectedOption=opt;
+        socket.emit('select_option',{optionId:opt.id});
+        document.getElementById('likeBtn').style.display='block';
+      };
+      container.appendChild(btn);
+    });
+  }
+}
+
+function renderReveal(data){
+  show('reveal');
+  document.getElementById('revealQuestion').textContent=data.question;
+  const list=document.getElementById('revealList');
+  list.innerHTML='';
+  data.lies.forEach(l=>{
+    const li=document.createElement('li');
+    li.textContent=`${l.lie} - ${l.voteCount} vote(s)`;
+    list.appendChild(li);
+  });
+  const truth=document.createElement('li');
+  truth.textContent=`Truth: ${data.truth.answer} - ${data.truth.voteCount} correct`;
+  list.appendChild(truth);
+}
+
+function renderScoreboard(data){
+  show('score');
+  const table=document.getElementById('scoreTable');
+  table.innerHTML='<tr><th>Rank</th><th>Name</th><th>Pts</th></tr>';
+  data.players.forEach(p=>{
+    const row=document.createElement('tr');
+    row.innerHTML=`<td>${p.rank}</td><td>${p.name}</td><td>${p.points}</td>`;
+    table.appendChild(row);
+  });
+}
 </script>
 </body>
 </html>

--- a/public/player.html
+++ b/public/player.html
@@ -153,6 +153,8 @@ document.getElementById('editAvatarBtn').onclick = () => {
 document.getElementById('avatarBtn').onclick = () => {
   const emoji = document.getElementById('emojiInput').value.trim() || '😀';
   const color = document.getElementById('colorInput').value || '#ffffff';
+  // Optimistically update the preview so players immediately see their choice
+  updateAvatarUI({ emoji, color });
   socket.emit('update_avatar',{emoji,color});
   editingAvatar = false;
   document.getElementById('avatarEdit').style.display = 'none';

--- a/public/player.html
+++ b/public/player.html
@@ -10,6 +10,7 @@
     #options button{display:block;margin:5px 0;}
     table{border-collapse:collapse;}
     td,th{border:1px solid #ccc;padding:4px 8px;}
+    .player-avatar{width:32px;height:32px;display:inline-flex;align-items:center;justify-content:center;border-radius:4px;color:#fff;margin-right:4px;}
   </style>
 </head>
 <body>
@@ -21,7 +22,15 @@
   </div>
 
   <div id="views" style="display:none;">
-    <div id="lobbyView" class="view">Waiting for game start...</div>
+    <div id="lobbyView" class="view">
+      <p>Waiting for game start...</p>
+      <div>
+        <span id="avatarPreview" class="player-avatar"></span>
+        <input id="emojiInput" placeholder="😊" style="width:3em;">
+        <input id="colorInput" type="color">
+        <button id="avatarBtn">Update Avatar</button>
+      </div>
+    </div>
     <div id="categoryView" class="view">
       <h3 id="categoryPrompt"></h3>
       <div id="categoryButtons"></div>
@@ -73,16 +82,32 @@ function hideAll(){ Object.values(views).forEach(v=>v.style.display='none'); }
 function show(name){ hideAll(); if(views[name]) views[name].style.display='block'; }
 function log(msg){ document.getElementById('log').textContent+=msg+'\n'; }
 
+function updateAvatarUI(avatar){
+  if(!avatar) return;
+  document.getElementById('avatarPreview').textContent = avatar.emoji;
+  document.getElementById('avatarPreview').style.backgroundColor = avatar.color;
+  document.getElementById('emojiInput').value = avatar.emoji;
+  document.getElementById('colorInput').value = avatar.color;
+}
+
 socket.on('connect', () => { document.getElementById('connection').textContent = 'Connected'; });
 socket.on('player_joined', data => {
   if(!playerId && data.player){
     playerId = data.player.id;
     document.getElementById('joinSection').style.display='none';
     document.getElementById('views').style.display='block';
+    updateAvatarUI(data.player.avatar);
   }
 });
 socket.on('player_reconnected', d => { if(d.playerId === playerId) socket.emit('request_game_state'); });
-socket.on('game_state_update', d => { gameState=d; render(); });
+socket.on('game_state_update', d => {
+  gameState=d;
+  if(playerId){
+    const me = (d.players||[]).find(p=>p.id===playerId);
+    if(me) updateAvatarUI(me.avatar);
+  }
+  render();
+});
 socket.on('sub_step_info', d => { subStep=d; render(); });
 socket.on('timer_update', d => { document.getElementById('timer').textContent='⏱ '+d.secondsRemaining+'s'; });
 socket.on('lie_submitted', () => { document.getElementById('lieStatus').textContent='Lie submitted!'; });
@@ -90,6 +115,10 @@ socket.on('option_selected', () => { document.getElementById('voteStatus').textC
 socket.on('truth_reveal_start', d => renderReveal(d));
 socket.on('scoreboard_update', d => renderScoreboard(d));
 socket.on('lie_liked', () => { document.getElementById('likeBtn').style.display='none'; });
+socket.on('player_avatar_updated', d => {
+  if(d.playerId === playerId) updateAvatarUI(d.avatar);
+  socket.emit('request_game_state');
+});
 socket.on('error', data => log('Error: '+data.message));
 
 document.getElementById('joinBtn').onclick = () => {
@@ -110,8 +139,15 @@ document.getElementById('likeBtn').onclick = () => {
   }
 };
 
+document.getElementById('avatarBtn').onclick = () => {
+  const emoji = document.getElementById('emojiInput').value.trim() || '😀';
+  const color = document.getElementById('colorInput').value || '#ffffff';
+  socket.emit('update_avatar',{emoji,color});
+};
+
 function render(){
   if(!gameState) return;
+  document.getElementById('avatarBtn').disabled = gameState.state !== 'lobby';
   switch(gameState.state){
     case 'lobby':
       show('lobby');

--- a/public/player.html
+++ b/public/player.html
@@ -24,11 +24,14 @@
   <div id="views" style="display:none;">
     <div id="lobbyView" class="view">
       <p>Waiting for game start...</p>
-      <div>
+      <div id="avatarSection">
         <span id="avatarPreview" class="player-avatar"></span>
-        <input id="emojiInput" placeholder="😊" style="width:3em;">
-        <input id="colorInput" type="color">
-        <button id="avatarBtn">Update Avatar</button>
+        <button id="editAvatarBtn">Edit Avatar</button>
+        <div id="avatarEdit" style="display:none; margin-top:5px;">
+          <input id="emojiInput" placeholder="😊" style="width:3em;">
+          <input id="colorInput" type="color">
+          <button id="avatarBtn">Update</button>
+        </div>
       </div>
     </div>
     <div id="categoryView" class="view">
@@ -67,6 +70,7 @@ let playerId = null;
 let gameState = null;
 let subStep = null;
 let selectedOption = null;
+let editingAvatar = false;
 
 const views = {
   lobby: document.getElementById('lobbyView'),
@@ -118,6 +122,8 @@ socket.on('lie_liked', () => { document.getElementById('likeBtn').style.display=
 socket.on('player_avatar_updated', d => {
   if(d.playerId === playerId) updateAvatarUI(d.avatar);
   socket.emit('request_game_state');
+  editingAvatar = false;
+  document.getElementById('avatarEdit').style.display = 'none';
 });
 socket.on('error', data => log('Error: '+data.message));
 
@@ -139,15 +145,28 @@ document.getElementById('likeBtn').onclick = () => {
   }
 };
 
+document.getElementById('editAvatarBtn').onclick = () => {
+  editingAvatar = !editingAvatar;
+  document.getElementById('avatarEdit').style.display = editingAvatar ? 'block' : 'none';
+};
+
 document.getElementById('avatarBtn').onclick = () => {
   const emoji = document.getElementById('emojiInput').value.trim() || '😀';
   const color = document.getElementById('colorInput').value || '#ffffff';
   socket.emit('update_avatar',{emoji,color});
+  editingAvatar = false;
+  document.getElementById('avatarEdit').style.display = 'none';
 };
 
 function render(){
   if(!gameState) return;
-  document.getElementById('avatarBtn').disabled = gameState.state !== 'lobby';
+  const editingAllowed = gameState.state === 'lobby';
+  document.getElementById('editAvatarBtn').disabled = !editingAllowed;
+  document.getElementById('avatarBtn').disabled = !editingAllowed;
+  if(!editingAllowed){
+    editingAvatar = false;
+    document.getElementById('avatarEdit').style.display = 'none';
+  }
   switch(gameState.state){
     case 'lobby':
       show('lobby');

--- a/public/player.html
+++ b/public/player.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Lie-Ability - Player</title>
+  <script src="/socket.io/socket.io.js"></script>
+  <style>
+    body{font-family:sans-serif;padding:20px;}
+    #options button{display:block;margin:5px 0;}
+  </style>
+</head>
+<body>
+  <h1>Player Controller</h1>
+  <div id="connection">Connecting...</div>
+  <div id="joinSection">
+    <input id="nameInput" placeholder="Name">
+    <button id="joinBtn">Join</button>
+  </div>
+  <div id="game" style="display:none;">
+    <div id="phase"></div>
+    <div id="question"></div>
+    <div id="lieSection" style="display:none;">
+      <input id="lieInput" placeholder="Enter your lie">
+      <button id="autoLie">Auto Lie</button>
+      <button id="submitLie">Submit</button>
+      <div id="lieStatus"></div>
+    </div>
+    <div id="options" style="display:none;"></div>
+    <div id="voteStatus"></div>
+    <div id="likeSection" style="display:none;">
+      <button id="likeBtn">Like Selected Lie</button>
+    </div>
+    <div id="timer"></div>
+  </div>
+  <pre id="log"></pre>
+
+<script>
+const socket = io();
+let playerId = null;
+let currentOptions = [];
+let selectedOption = null;
+
+function log(msg){document.getElementById('log').textContent += msg+'\n';}
+
+socket.on('connect', ()=>{
+  document.getElementById('connection').textContent = 'Connected';
+});
+
+socket.on('player_joined', data => {
+  if(!playerId && data.player){
+    playerId = data.player.id;
+    document.getElementById('joinSection').style.display='none';
+    document.getElementById('game').style.display='block';
+  }
+  log(`${data.player.name} joined`);
+});
+
+socket.on('player_reconnected', d=>{
+  if(d.playerId === playerId){
+    socket.emit('request_game_state');
+  }
+});
+
+socket.on('game_state_update', data => { updateGame(data); });
+socket.on('sub_step_info', info => { updateSubStep(info); });
+
+socket.on('lie_submitted', ()=>{
+  document.getElementById('lieStatus').textContent='Lie submitted!';
+});
+
+socket.on('option_selected', ()=>{
+  document.getElementById('voteStatus').textContent='Vote submitted!';
+});
+
+socket.on('timer_update', data => {
+  document.getElementById('timer').textContent='⏱ '+data.secondsRemaining+'s';
+});
+
+socket.on('lie_liked', ()=>{
+  document.getElementById('likeSection').style.display='none';
+});
+
+socket.on('error', data => { log('Error: '+data.message); });
+
+document.getElementById('joinBtn').onclick = () => {
+  const name = document.getElementById('nameInput').value.trim();
+  if(name){
+    socket.emit('join_game',{playerName:name});
+  }
+};
+
+document.getElementById('submitLie').onclick = () => {
+  const lie = document.getElementById('lieInput').value.trim();
+  if(lie){
+    socket.emit('submit_lie',{lie});
+  }
+};
+
+document.getElementById('autoLie').onclick = () => { socket.emit('auto_lie'); };
+
+function updateGame(data){
+  document.getElementById('phase').textContent='Phase: '+data.state;
+  if(data.currentQuestionData){
+    document.getElementById('question').textContent=data.currentQuestionData.question;
+  }
+}
+
+function updateSubStep(info){
+  if(info.state==='lie_submission'){
+    document.getElementById('lieSection').style.display='block';
+  }else{
+    document.getElementById('lieSection').style.display='none';
+  }
+
+  if(info.state==='option_selection' && info.options){
+    currentOptions = info.options;
+    const container = document.getElementById('options');
+    container.innerHTML='';
+    info.options.forEach(opt=>{
+      const btn=document.createElement('button');
+      btn.textContent=opt.text;
+      btn.onclick=()=>{
+        selectedOption=opt;
+        socket.emit('select_option',{optionId:opt.id});
+        document.getElementById('voteStatus').textContent='Voted for '+opt.text;
+      };
+      container.appendChild(btn);
+    });
+    container.style.display='block';
+    document.getElementById('likeSection').style.display='block';
+  }else{
+    document.getElementById('options').style.display='none';
+    document.getElementById('likeSection').style.display='none';
+  }
+}
+
+document.getElementById('likeBtn').onclick = () => {
+  if(selectedOption && selectedOption.submittedById){
+    socket.emit('like_lie',{likedPlayerId:selectedOption.submittedById});
+  }
+};
+</script>
+</body>
+</html>

--- a/src/models/Game.js
+++ b/src/models/Game.js
@@ -133,6 +133,27 @@ class Game {
     return true;
   }
 
+  updatePlayerAvatar(playerId, emoji, color) {
+    if (this.state !== GAME_STATES.LOBBY) {
+      return { success: false, error: 'Cannot change avatar after game start' };
+    }
+
+    const player = this.players.get(playerId);
+    if (!player) {
+      return { success: false, error: 'Player not found' };
+    }
+
+    player.setAvatar(emoji, color);
+
+    this.broadcastToAll(SOCKET_EVENTS.PLAYER_AVATAR_UPDATED, {
+      playerId,
+      avatar: player.avatar
+    });
+
+    this.broadcastGameStateAndSubStep();
+    return { success: true };
+  }
+
   // Game Control Methods
   startGame() {
     if (this.state !== GAME_STATES.LOBBY) {

--- a/src/models/Game.js
+++ b/src/models/Game.js
@@ -849,11 +849,9 @@ class Game {
   }
 
   broadcastToAll(event, data) {
-    for (const player of this.players.values()) {
-      if (player.socketId) {
-        this.io.to(player.socketId).emit(event, data);
-      }
-    }
+    // Emit to every connected socket so that observer clients like the host
+    // screen receive updates without needing to join as a player.
+    this.io.emit(event, data);
   }
 
   getRandomLieForCurrentQuestion() {

--- a/src/models/Player.js
+++ b/src/models/Player.js
@@ -32,6 +32,10 @@ class Player {
     return { emoji, color };
   }
 
+  setAvatar(emoji, color) {
+    this.avatar = { emoji, color };
+  }
+
   updateSocketId(newSocketId) {
     this.socketId = newSocketId;
     this.status = PLAYER_STATUS.CONNECTED;

--- a/src/server.js
+++ b/src/server.js
@@ -264,6 +264,25 @@ io.on('connection', (socket) => {
     }
   });
 
+  // Handle avatar updates
+  socket.on(SOCKET_EVENTS.UPDATE_AVATAR, (data) => {
+    try {
+      const playerId = getPlayerIdBySocketId(socket.id);
+      if (!playerId) {
+        socket.emit(SOCKET_EVENTS.ERROR, { message: 'Player not found' });
+        return;
+      }
+
+      const result = game.updatePlayerAvatar(playerId, data.emoji, data.color);
+      if (!result.success) {
+        socket.emit(SOCKET_EVENTS.ERROR, { message: result.error });
+      }
+    } catch (error) {
+      console.error('Error in UPDATE_AVATAR:', error);
+      socket.emit(SOCKET_EVENTS.ERROR, { message: 'Failed to update avatar' });
+    }
+  });
+
   // Handle game state request
   socket.on(SOCKET_EVENTS.REQUEST_GAME_STATE, () => {
     try {

--- a/src/server.js
+++ b/src/server.js
@@ -390,6 +390,15 @@ app.get('/tests/debug-interface.html', (req, res) => {
   res.sendFile(path.join(__dirname, '../tests/debug-interface.html'));
 });
 
+// Routes for lightweight demo front-end
+app.get('/host', (req, res) => {
+  res.sendFile(path.join(__dirname, '../public/host.html'));
+});
+
+app.get('/player', (req, res) => {
+  res.sendFile(path.join(__dirname, '../public/player.html'));
+});
+
 // Serve static files for frontend (when we build it)
 app.use(express.static(path.join(__dirname, '../public')));
 

--- a/src/server.js
+++ b/src/server.js
@@ -276,13 +276,7 @@ io.on('connection', (socket) => {
       if (playerId) {
         socket.emit('sub_step_info', game.getSubStepInfo(playerId));
       } else {
-        // Send basic sub-step info for non-joined users
-        socket.emit('sub_step_info', { 
-          state: game.state, 
-          isSelector: false, 
-          hasSubmittedLie: false, 
-          hasSelectedOption: false 
-        });
+        socket.emit(SOCKET_EVENTS.HOST_SUB_STEP_INFO, game.getSubStepInfo(null));
       }
     } catch (error) {
       console.error('Error in REQUEST_GAME_STATE:', error);

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -57,6 +57,7 @@ const SOCKET_EVENTS = {
   AUTO_LIE: 'auto_lie',
   SELECT_OPTION: 'select_option',
   LIKE_LIE: 'like_lie',
+  UPDATE_AVATAR: 'update_avatar',
   REQUEST_GAME_STATE: 'request_game_state',
   CHANGE_QUESTION_PACK: 'change_question_pack',
   
@@ -75,6 +76,7 @@ const SOCKET_EVENTS = {
   GAME_ENDED: 'game_ended',
   ERROR: 'error',
   TIMER_UPDATE: 'timer_update',
+  PLAYER_AVATAR_UPDATED: 'player_avatar_updated',
   HOST_SUB_STEP_INFO: 'host_sub_step_info',
   AVAILABLE_QUESTION_PACKS: 'available_question_packs'
 };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -75,6 +75,7 @@ const SOCKET_EVENTS = {
   GAME_ENDED: 'game_ended',
   ERROR: 'error',
   TIMER_UPDATE: 'timer_update',
+  HOST_SUB_STEP_INFO: 'host_sub_step_info',
   AVAILABLE_QUESTION_PACKS: 'available_question_packs'
 };
 


### PR DESCRIPTION
## Summary
- add minimal host and player pages under `public/`
- expose `/host` and `/player` express routes
- serve simple socket.io clients for gameplay demo

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dce6f2f3c8330834e202680aa986a