### PR TITLE
Rename playersTooled field

### DIFF
--- a/public/host.html
+++ b/public/host.html
@@ -198,10 +198,10 @@ function renderReveal(data){
 function renderScoreboard(data){
   show('score');
   const table=document.getElementById('scoreTable');
-  table.innerHTML='<tr><th>Rank</th><th>Name</th><th>Pts</th></tr>';
+  table.innerHTML='<tr><th>Rank</th><th>Name</th><th>Pts</th><th>Fooled</th></tr>';
   data.players.forEach(p => {
     const row=document.createElement('tr');
-    row.innerHTML = `<td>${p.rank}</td><td>${p.name}</td><td>${p.points}</td>`;
+    row.innerHTML = `<td>${p.rank}</td><td>${p.name}</td><td>${p.points}</td><td>${p.playersFooled}</td>`;
     table.appendChild(row);
   });
 }

--- a/public/player.html
+++ b/public/player.html
@@ -253,10 +253,10 @@ function renderReveal(data){
 function renderScoreboard(data){
   show('score');
   const table=document.getElementById('scoreTable');
-  table.innerHTML='<tr><th>Rank</th><th>Name</th><th>Pts</th></tr>';
+  table.innerHTML='<tr><th>Rank</th><th>Name</th><th>Pts</th><th>Fooled</th></tr>';
   data.players.forEach(p=>{
     const row=document.createElement('tr');
-    row.innerHTML=`<td>${p.rank}</td><td>${p.name}</td><td>${p.points}</td>`;
+    row.innerHTML=`<td>${p.rank}</td><td>${p.name}</td><td>${p.points}</td><td>${p.playersFooled}</td>`;
     table.appendChild(row);
   });
 }

--- a/src/models/Game.js
+++ b/src/models/Game.js
@@ -615,7 +615,7 @@ class Game {
 
       const foolPoints = votesReceived * pointMultiplier.FOOL_PLAYER;
       player.addPoints(foolPoints);
-      player.roundStats.playersTooled += votesReceived;
+      player.roundStats.playersFooled += votesReceived;
       
       if (foolPoints > 0) {
         console.log(`🎯 [SCORING] ${player.name} fooled ${votesReceived} players (+${foolPoints} points)`);

--- a/src/models/Player.js
+++ b/src/models/Player.js
@@ -21,7 +21,7 @@ class Player {
     this.roundStats = {
       liesSubmitted: [],
       correctGuesses: 0,
-      playersTooled: 0,
+      playersFooled: 0,
       likesReceived: 0
     };
   }
@@ -85,7 +85,7 @@ class Player {
     this.roundStats = {
       liesSubmitted: [],
       correctGuesses: 0,
-      playersTooled: 0,
+      playersFooled: 0,
       likesReceived: 0
     };
     this.resetForNewQuestion();
@@ -114,7 +114,8 @@ class Player {
       points: this.points,
       avatar: this.avatar,
       lastLie: this.roundStats.liesSubmitted[this.roundStats.liesSubmitted.length - 1] || null,
-      likesReceived: this.roundStats.likesReceived
+      likesReceived: this.roundStats.likesReceived,
+      playersFooled: this.roundStats.playersFooled
     };
   }
 }


### PR DESCRIPTION
## Summary
- rename `playersTooled` to `playersFooled`
- update scoring logic
- show how many players each contestant fooled on scoreboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ddd51f0e0833097f1fb6ce57b7feb