### PR TITLE
feat: add svelte frontend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,9 @@ npm install
 
 3. Start the server:
 ```bash
-npm run dev
+./start.sh
 ```
-
-4. Open your browser and navigate to:
-```
-http://localhost:3000
-```
+4. The script opens the host UI automatically at http://localhost:5173/host
 
 ### For Production
 ```bash
@@ -100,6 +96,7 @@ lie-ability-game/
 
 The frontend is being rewritten in **Svelte** under the `svelte/` directory.
 Run `npm install` inside that folder and `npm run dev` to start the Vite dev server.
+Alternatively, run `./start.sh` from the repository root to start both backend and frontend together.
 The build output is placed in `public/`, which is served by the Express backend.
 
 ## 🎯 Question Packs

--- a/README.md
+++ b/README.md
@@ -89,11 +89,18 @@ lie-ability-game/
 │   ├── unit/                # Unit tests (future)
 │   └── integration/         # Integration tests (future)
 ├── public/
-│   └── index.html           # Main frontend (placeholder for now)
+│   └── index.html           # Built frontend assets
+├── svelte/                  # Svelte source for the new frontend
 ├── docs/                    # Documentation (future)
 ├── package.json
 └── README.md
 ```
+
+## 🎨 Frontend Development
+
+The frontend is being rewritten in **Svelte** under the `svelte/` directory.
+Run `npm install` inside that folder and `npm run dev` to start the Vite dev server.
+The build output is placed in `public/`, which is served by the Express backend.
 
 ## 🎯 Question Packs
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Start backend and frontend concurrently
+
+backend_port=3000
+frontend_port=5173
+shared_screen_url="http://localhost:${frontend_port}/host"
+
+npm run dev &
+backend_pid=$!
+
+(cd svelte && npm run dev &) 
+frontend_pid=$!
+
+# Wait a moment for servers to start
+sleep 3
+
+if command -v xdg-open >/dev/null; then
+  xdg-open "$shared_screen_url" &
+elif command -v open >/dev/null; then
+  open "$shared_screen_url" &
+else
+  echo "Open $shared_screen_url in your browser"
+fi
+
+trap 'kill $backend_pid $frontend_pid' INT TERM
+wait $backend_pid $frontend_pid

--- a/svelte/host.html
+++ b/svelte/host.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lie-Ability Host</title>
+</head>
+<body>
+  <div id="host"></div>
+  <script type="module" src="/src/host.js"></script>
+</body>
+</html>

--- a/svelte/index.html
+++ b/svelte/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lie-Ability</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/main.js"></script>
+</body>
+</html>

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "lie-ability-frontend",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^2.0.0",
+    "svelte": "^3.59.0",
+    "vite": "^4.0.0",
+    "socket.io-client": "^4.7.2"
+  }
+}

--- a/svelte/player.html
+++ b/svelte/player.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lie-Ability Player</title>
+</head>
+<body>
+  <div id="player"></div>
+  <script type="module" src="/src/player.js"></script>
+</body>
+</html>

--- a/svelte/src/App.svelte
+++ b/svelte/src/App.svelte
@@ -1,0 +1,32 @@
+<script>
+  let message = 'Frontend Coming Soon!'
+</script>
+
+<main>
+  <h1>🎮 Lie-Ability</h1>
+  <p>{message}</p>
+  <nav>
+    <a href="/host">Host Screen</a>
+    <a href="/player">Player Screen</a>
+  </nav>
+</main>
+
+<style>
+  main {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    padding: 2rem;
+    text-align: center;
+  }
+
+  nav {
+    margin-top: 1rem;
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+  }
+
+  a {
+    color: #2c3e50;
+    text-decoration: none;
+  }
+</style>

--- a/svelte/src/Host.svelte
+++ b/svelte/src/Host.svelte
@@ -1,0 +1,22 @@
+<script>
+  import { onMount } from 'svelte'
+  import io from 'socket.io-client'
+
+  let socket
+  onMount(() => {
+    socket = io()
+  })
+</script>
+
+<main>
+  <h1>Host Screen</h1>
+  <p>Game state will appear here.</p>
+</main>
+
+<style>
+  main {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    padding: 2rem;
+    text-align: center;
+  }
+</style>

--- a/svelte/src/Player.svelte
+++ b/svelte/src/Player.svelte
@@ -1,0 +1,22 @@
+<script>
+  import { onMount } from 'svelte'
+  import io from 'socket.io-client'
+
+  let socket
+  onMount(() => {
+    socket = io()
+  })
+</script>
+
+<main>
+  <h1>Player Screen</h1>
+  <p>Your personal interactions will go here.</p>
+</main>
+
+<style>
+  main {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    padding: 2rem;
+    text-align: center;
+  }
+</style>

--- a/svelte/src/host.js
+++ b/svelte/src/host.js
@@ -1,0 +1,7 @@
+import Host from './Host.svelte'
+
+const app = new Host({
+  target: document.getElementById('host')
+})
+
+export default app

--- a/svelte/src/main.js
+++ b/svelte/src/main.js
@@ -1,0 +1,7 @@
+import App from './App.svelte'
+
+const app = new App({
+  target: document.getElementById('app')
+})
+
+export default app

--- a/svelte/src/player.js
+++ b/svelte/src/player.js
@@ -1,0 +1,7 @@
+import Player from './Player.svelte'
+
+const app = new Player({
+  target: document.getElementById('player')
+})
+
+export default app

--- a/svelte/vite.config.js
+++ b/svelte/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
+
+export default defineConfig({
+  plugins: [svelte()],
+  build: {
+    outDir: '../public',
+    emptyOutDir: false
+  }
+})


### PR DESCRIPTION
## Summary
- scaffold Svelte frontend in `svelte/`
- set up Vite build to output into `public/`
- add host, player and main entry components
- document Svelte frontend in README

## Testing Done
- `npm test` *(fails: jest not found)*
- `npm start` *(fails: Cannot find module 'express')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684e3db30ce4833089482b365947de2c