### PR TITLE
fix: auto install deps in start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ npm install
 ```bash
 ./start.sh
 ```
-4. The script installs missing packages with `npm install --legacy-peer-deps`
-   and opens the host UI automatically at http://localhost:5173/host
+4. The script ensures all backend and frontend packages are installed with
+   `npm install --legacy-peer-deps` and opens the host UI automatically at
+   http://localhost:5173/host
 
 ### For Production
 ```bash

--- a/start.sh
+++ b/start.sh
@@ -6,13 +6,13 @@ backend_port=3000
 frontend_port=5173
 shared_screen_url="http://localhost:${frontend_port}/host"
 
-# Install backend dependencies if missing
-if [ ! -d node_modules/express ]; then
+# Ensure backend dependencies are installed
+if ! npm ls express >/dev/null 2>&1; then
   npm install --legacy-peer-deps
 fi
 
-# Install frontend dependencies if missing or incomplete
-if [ ! -d svelte/node_modules/socket.io-client ]; then
+# Ensure frontend dependencies are installed
+if ! (cd svelte && npm ls socket.io-client >/dev/null 2>&1); then
   (cd svelte && npm install --legacy-peer-deps)
 fi
 


### PR DESCRIPTION
## Summary
- install frontend and backend dependencies from `start.sh` when needed

## Testing Done
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684e4129a4e083308ccbb50c160b473a