### PR TITLE
fix: add adapter-auto dev dependency

### DIFF
--- a/svelte/package.json
+++ b/svelte/package.json
@@ -12,6 +12,7 @@
     "@sveltejs/vite-plugin-svelte": "^2.0.0",
     "svelte": "^3.59.0",
     "vite": "^4.0.0",
-    "socket.io-client": "^4.7.2"
+    "socket.io-client": "^4.7.2",
+    "@sveltejs/adapter-auto": "^2.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add @sveltejs/adapter-auto to svelte devDependencies

## Testing Done
- `npm install` *(failed: no network)*
- `npm start` *(failed: missing module 'express')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684e45a5ad608330955d6621e9b4bfc9