### PR TITLE
feat: load lobby from landing screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm install
 ./start.sh
 ```
 4. The script ensures all backend and frontend packages are installed with
-   `npm install --legacy-peer-deps` and opens the host UI automatically at
+   `npm install --legacy-peer-deps` and opens the lobby at
    http://localhost:5173/host
 
 ### For Production

--- a/public/index.html
+++ b/public/index.html
@@ -89,6 +89,9 @@
             <a href="/tests/debug-interface.html" class="link">
                 🔧 Backend Debug Interface
             </a>
+            <a href="http://localhost:5173/host" class="link">
+                🎬 Host Screen
+            </a>
             <a href="/api/health" class="link">
                 📊 Server Health Check
             </a>

--- a/svelte/src/App.svelte
+++ b/svelte/src/App.svelte
@@ -1,14 +1,21 @@
 <script>
+  import Host from './Host.svelte'
   let message = 'Frontend Coming Soon!'
+  let showHost = false
+  const openHost = () => { showHost = true }
 </script>
 
 <main>
-  <h1>🎮 Lie-Ability</h1>
-  <p>{message}</p>
-  <nav>
-    <a href="/host">Host Screen</a>
-    <a href="/player">Player Screen</a>
-  </nav>
+  {#if showHost}
+    <Host/>
+  {:else}
+    <h1>🎮 Lie-Ability</h1>
+    <p>{message}</p>
+    <nav>
+      <button on:click={openHost}>Host Screen</button>
+      <a href="/player">Player Screen</a>
+    </nav>
+  {/if}
 </main>
 
 <style>
@@ -28,5 +35,12 @@
   a {
     color: #2c3e50;
     text-decoration: none;
+  }
+
+  button {
+    background: none;
+    border: 1px solid #2c3e50;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
   }
 </style>

--- a/svelte/src/Host.svelte
+++ b/svelte/src/Host.svelte
@@ -19,7 +19,10 @@
   const startGame = () => socket.emit('start_game')
 
   onMount(() => {
-    socket = io()
+    const socketUrl = window.location.port === '5173'
+      ? 'http://localhost:3000'
+      : window.location.origin
+    socket = io(socketUrl)
     socket.on('connect', () => socket.emit('request_game_state'))
     socket.on('game_state_update', d => { gameState = d })
     socket.on('host_sub_step_info', d => { subStep = d })

--- a/svelte/src/Host.svelte
+++ b/svelte/src/Host.svelte
@@ -1,16 +1,63 @@
 <script>
   import { onMount } from 'svelte'
   import io from 'socket.io-client'
+  import Lobby from './components/Lobby.svelte'
+  import CategoryView from './components/CategoryView.svelte'
+  import QuestionView from './components/QuestionView.svelte'
+  import WaitingView from './components/WaitingView.svelte'
+  import OptionsView from './components/OptionsView.svelte'
+  import RevealView from './components/RevealView.svelte'
+  import Scoreboard from './components/Scoreboard.svelte'
 
   let socket
+  let gameState = null
+  let subStep = null
+  let timer = 0
+  let revealData = null
+  let scoreboard = null
+
+  const startGame = () => socket.emit('start_game')
+
   onMount(() => {
     socket = io()
+    socket.on('connect', () => socket.emit('request_game_state'))
+    socket.on('game_state_update', d => { gameState = d })
+    socket.on('host_sub_step_info', d => { subStep = d })
+    socket.on('timer_update', d => { timer = d.secondsRemaining })
+    socket.on('truth_reveal_start', d => { revealData = d })
+    socket.on('scoreboard_update', d => { scoreboard = d })
+    socket.on('player_joined', () => socket.emit('request_game_state'))
+    socket.on('player_left', () => socket.emit('request_game_state'))
   })
+
+  $: players = gameState?.players || []
+  $: currentState = gameState?.state
+  $: currentQuestion = subStep?.question || gameState?.currentQuestionData
+  $: categories = subStep?.categories || []
+  $: options = subStep?.options || []
 </script>
 
 <main>
-  <h1>Host Screen</h1>
-  <p>Game state will appear here.</p>
+  {#if currentState === 'lobby'}
+    <Lobby {players} onStart={startGame}/>
+  {:else if currentState === 'category_selection'}
+    <CategoryView {categories}
+      selectorName={players.find(p => p.id === gameState.categorySelector)?.name}
+      isSelector={subStep?.isSelector}/>
+  {:else if currentState === 'question_reading'}
+    <QuestionView question={currentQuestion}/>
+  {:else if currentState === 'lie_submission'}
+    <WaitingView/>
+  {:else if currentState === 'option_selection'}
+    <OptionsView {options}/>
+  {:else if currentState === 'truth_reveal'}
+    <RevealView reveal={revealData}/>
+  {:else if currentState === 'scoreboard' || currentState === 'game_ended'}
+    <Scoreboard players={scoreboard?.players || []}/>
+  {/if}
+  {#if timer}
+    <div class="timer">⏱ {timer}s</div>
+  {/if}
 </main>
 
 <style>
@@ -18,5 +65,9 @@
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     padding: 2rem;
     text-align: center;
+  }
+  .timer {
+    margin-top: 1rem;
+    font-size: 1.2rem;
   }
 </style>

--- a/svelte/src/Player.svelte
+++ b/svelte/src/Player.svelte
@@ -4,7 +4,10 @@
 
   let socket
   onMount(() => {
-    socket = io()
+    const socketUrl = window.location.port === '5173'
+      ? 'http://localhost:3000'
+      : window.location.origin
+    socket = io(socketUrl)
   })
 </script>
 

--- a/svelte/src/components/CategoryView.svelte
+++ b/svelte/src/components/CategoryView.svelte
@@ -1,0 +1,24 @@
+<script>
+  export let categories = []
+  export let selectorName = ''
+  export let isSelector = false
+</script>
+
+<section class="category">
+  <h3>{isSelector ? 'You choose the category' : `${selectorName} is choosing the category...`}</h3>
+  <ul>
+    {#each categories as c}
+      <li>{c.category}</li>
+    {/each}
+  </ul>
+</section>
+
+<style>
+  ul {
+    list-style: none;
+    padding: 0;
+  }
+  li {
+    margin: 0.25rem 0;
+  }
+</style>

--- a/svelte/src/components/Lobby.svelte
+++ b/svelte/src/components/Lobby.svelte
@@ -1,0 +1,26 @@
+<script>
+  import PlayerList from './PlayerList.svelte'
+  export let players = []
+  export let onStart = () => {}
+</script>
+
+<section class="lobby">
+  <h2>Join the Game!</h2>
+  <PlayerList {players}/>
+  <button on:click={onStart} disabled={players.length < 2}>
+    {players.length < 2 ? 'Need at least 2 players' : 'Start Game'}
+  </button>
+</section>
+
+<style>
+  .lobby {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+  }
+  button {
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+  }
+</style>

--- a/svelte/src/components/OptionsView.svelte
+++ b/svelte/src/components/OptionsView.svelte
@@ -1,0 +1,26 @@
+<script>
+  export let options = []
+  const letters = 'ABCDEFGH'
+</script>
+
+<section class="options">
+  <h3>Which answer is the truth?</h3>
+  <ul>
+    {#each options as o, index}
+      <li
+        data-letter={letters[index] || index + 1}
+        data-length={o.text.length > 50 ? 'very-long' : o.text.length > 25 ? 'long' : undefined}
+      >{o.text}</li>
+    {/each}
+  </ul>
+</section>
+
+<style>
+  ul {
+    list-style: none;
+    padding: 0;
+  }
+  li {
+    margin: 0.25rem 0;
+  }
+</style>

--- a/svelte/src/components/PlayerList.svelte
+++ b/svelte/src/components/PlayerList.svelte
@@ -1,0 +1,32 @@
+<script>
+  export let players = []
+</script>
+
+<ul class="player-list">
+  {#each players as p}
+    <li class="player-item">
+      <span class="player-avatar" style="background:{p.avatar?.color}">{p.avatar?.emoji}</span>
+      <span class="player-name">{p.name}</span>
+    </li>
+  {/each}
+</ul>
+
+<style>
+  .player-list {
+    list-style: none;
+    padding: 0;
+  }
+  .player-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0.25rem 0;
+  }
+  .player-avatar {
+    width: 1.5rem;
+    height: 1.5rem;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+  }
+</style>

--- a/svelte/src/components/QuestionView.svelte
+++ b/svelte/src/components/QuestionView.svelte
@@ -1,0 +1,17 @@
+<script>
+  export let question = null
+</script>
+
+{#if question}
+<section class="question">
+  <div class="category">{question.category}</div>
+  <h3>{question.question}</h3>
+</section>
+{/if}
+
+<style>
+  .category {
+    font-size: 0.9rem;
+    opacity: 0.8;
+  }
+</style>

--- a/svelte/src/components/RevealView.svelte
+++ b/svelte/src/components/RevealView.svelte
@@ -1,0 +1,26 @@
+<script>
+  export let reveal = null
+</script>
+
+{#if reveal}
+<section class="reveal">
+  <h3>{reveal.question}</h3>
+  <ul>
+    {#each reveal.lies as l}
+      <li>{l.lie} - {l.voteCount} {l.voteCount === 1 ? 'vote' : 'votes'}</li>
+    {/each}
+    <li class="truth">Truth: {reveal.truth.answer} - {reveal.truth.voteCount} correct</li>
+  </ul>
+</section>
+{/if}
+
+<style>
+  ul {
+    list-style: none;
+    padding: 0;
+  }
+  .truth {
+    margin-top: 0.5rem;
+    font-weight: bold;
+  }
+</style>

--- a/svelte/src/components/Scoreboard.svelte
+++ b/svelte/src/components/Scoreboard.svelte
@@ -1,0 +1,47 @@
+<script>
+  export let players = []
+  const medals = ['🥇', '🥈', '🥉']
+</script>
+
+<section class="scoreboard">
+  <h2>Scoreboard</h2>
+  <div class="scoreboard-list">
+    {#each players as p, index}
+      <div class="score-row">
+        <div class="rank-cell">
+          <span class="rank-medal">{medals[index] || ''}</span>
+          {#if index >= 3}
+            <span>#{p.rank}</span>
+          {/if}
+        </div>
+        <div class="name-cell">{p.name}</div>
+        <div class="lie-cell">{p.lastLie || 'No lie submitted'}</div>
+        <div class="fooled-cell">{p.playersFooled} fooled</div>
+        <div class="score-cell">{p.points}</div>
+      </div>
+    {/each}
+  </div>
+</section>
+
+<style>
+  .scoreboard-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-top: 1rem;
+  }
+  .score-row {
+    display: grid;
+    grid-template-columns: 4rem 1fr 2fr 3rem 3rem;
+    gap: 0.5rem;
+    align-items: center;
+  }
+  .rank-cell {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+  .rank-medal {
+    font-size: 1.2rem;
+  }
+</style>

--- a/svelte/src/components/WaitingView.svelte
+++ b/svelte/src/components/WaitingView.svelte
@@ -1,0 +1,24 @@
+<section class="waiting">
+  <h2>Players are crafting their lies</h2>
+  <div class="dots">
+    <span></span><span></span><span></span>
+  </div>
+</section>
+
+<style>
+  .waiting {
+    text-align: center;
+  }
+  .dots span {
+    animation: blink 1s infinite alternate;
+    display: inline-block;
+    width: 0.5rem;
+    height: 0.5rem;
+    margin: 0 0.2rem;
+    background: #555;
+    border-radius: 50%;
+  }
+  .dots span:nth-child(2) { animation-delay: 0.3s }
+  .dots span:nth-child(3) { animation-delay: 0.6s }
+  @keyframes blink { from { opacity: 0.3 } to { opacity: 1 } }
+</style>


### PR DESCRIPTION
## Summary
- show the Host lobby when clicking the Host Screen button
- add simple button styles

## Testing Done
- `npm test` *(fails: jest not found)*
- `npm install` in `svelte/` *(fails: forbidden package download)*

------
https://chatgpt.com/codex/tasks/task_e_684e471fdb28833082e9d0661562675a