### PR TITLE
feat: add svelte player ui

### DIFF
--- a/svelte/src/Player.svelte
+++ b/svelte/src/Player.svelte
@@ -1,19 +1,109 @@
 <script>
   import { onMount } from 'svelte'
   import io from 'socket.io-client'
+  import JoinView from './components/JoinView.svelte'
+  import CategoryPicker from './components/CategoryPicker.svelte'
+  import LieInput from './components/LieInput.svelte'
+  import OptionButtons from './components/OptionButtons.svelte'
+  import WaitingView from './components/WaitingView.svelte'
+  import QuestionView from './components/QuestionView.svelte'
+  import RevealView from './components/RevealView.svelte'
+  import Scoreboard from './components/Scoreboard.svelte'
+  import { SOCKET_EVENTS, GAME_STATES } from './constants'
 
   let socket
+  let playerJoined = false
+  let playerId = ''
+  let playerName = ''
+  let joinError = ''
+
+  let gameState = null
+  let subStep = null
+  let timer = 0
+  let revealData = null
+  let scoreboard = null
+
+  const joinGame = name => {
+    joinError = ''
+    playerName = name.trim()
+    if (playerName) {
+      socket.emit(SOCKET_EVENTS.JOIN_GAME, { playerName })
+    }
+  }
+
+  const selectCategory = id => socket.emit(SOCKET_EVENTS.SELECT_CATEGORY, { categoryId: id })
+  const submitLie = lie => socket.emit(SOCKET_EVENTS.SUBMIT_LIE, { lie })
+  const autoLie = () => socket.emit(SOCKET_EVENTS.AUTO_LIE)
+  const selectOption = id => socket.emit(SOCKET_EVENTS.SELECT_OPTION, { optionId: id })
+
   onMount(() => {
     const socketUrl = window.location.port === '5173'
       ? 'http://localhost:3000'
       : window.location.origin
     socket = io(socketUrl)
+
+    socket.on('connect', () => {
+      socket.emit(SOCKET_EVENTS.REQUEST_GAME_STATE)
+    })
+
+    socket.on(SOCKET_EVENTS.GAME_STATE_UPDATE, d => { gameState = d })
+    socket.on('sub_step_info', d => { subStep = d })
+    socket.on(SOCKET_EVENTS.TIMER_UPDATE, d => { timer = d.secondsRemaining })
+    socket.on(SOCKET_EVENTS.TRUTH_REVEAL_START, d => { revealData = d })
+    socket.on(SOCKET_EVENTS.SCOREBOARD_UPDATE, d => { scoreboard = d })
+
+    const handleJoin = data => {
+      playerJoined = true
+      playerId = data.player?.id || data.playerId
+      gameState = data.gameState
+    }
+
+    socket.on(SOCKET_EVENTS.PLAYER_JOINED, handleJoin)
+    socket.on(SOCKET_EVENTS.PLAYER_RECONNECTED, handleJoin)
+    socket.on(SOCKET_EVENTS.ERROR, d => { joinError = d.message })
   })
+
+  $: currentState = gameState?.state
+  $: categories = subStep?.categories || []
+  $: question = subStep?.question || gameState?.currentQuestionData
+  $: options = subStep?.options || []
 </script>
 
 <main>
-  <h1>Player Screen</h1>
-  <p>Your personal interactions will go here.</p>
+  {#if !playerJoined}
+    <JoinView onJoin={joinGame} {joinError}/>
+  {:else}
+    {#if currentState === GAME_STATES.LOBBY}
+      <p>Waiting for the host to start...</p>
+    {:else if currentState === GAME_STATES.CATEGORY_SELECTION}
+      {#if subStep?.isSelector}
+        <CategoryPicker {categories} onSelect={selectCategory}/>
+      {:else}
+        <p>Waiting for category choice...</p>
+      {/if}
+    {:else if currentState === GAME_STATES.QUESTION_READING}
+      <QuestionView {question}/>
+    {:else if currentState === GAME_STATES.LIE_SUBMISSION}
+      {#if !subStep?.hasSubmittedLie}
+        <LieInput onSubmit={submitLie} onAuto={autoLie}/>
+      {:else}
+        <WaitingView/>
+      {/if}
+    {:else if currentState === GAME_STATES.OPTION_SELECTION}
+      {#if !subStep?.hasSelectedOption}
+        <OptionButtons {options} onSelect={selectOption}/>
+      {:else}
+        <WaitingView/>
+      {/if}
+    {:else if currentState === GAME_STATES.TRUTH_REVEAL}
+      <RevealView reveal={revealData}/>
+    {:else if currentState === GAME_STATES.SCOREBOARD || currentState === GAME_STATES.GAME_ENDED}
+      <Scoreboard players={scoreboard?.players || []}/>
+    {/if}
+    {#if timer}
+      <div class="timer">⏱ {timer}s</div>
+    {/if}
+  {/if}
 </main>
 
 <style>
@@ -22,4 +112,5 @@
     padding: 2rem;
     text-align: center;
   }
+  .timer { margin-top: 1rem; font-size: 1.2rem }
 </style>

--- a/svelte/src/components/CategoryPicker.svelte
+++ b/svelte/src/components/CategoryPicker.svelte
@@ -1,0 +1,19 @@
+<script>
+  export let categories = []
+  export let onSelect = () => {}
+</script>
+
+<section class="category-picker">
+  <h3>Choose a Category</h3>
+  <ul>
+    {#each categories as c}
+      <li><button on:click={() => onSelect(c.id)}>{c.category}</button></li>
+    {/each}
+  </ul>
+</section>
+
+<style>
+  ul { list-style:none; padding:0 }
+  li { margin:0.25rem 0 }
+  button { padding:0.5rem 1rem }
+</style>

--- a/svelte/src/components/JoinView.svelte
+++ b/svelte/src/components/JoinView.svelte
@@ -1,0 +1,22 @@
+<script>
+  export let onJoin = () => {}
+  export let error = ''
+  let name = ''
+  const submit = () => onJoin(name)
+</script>
+
+<section class="join">
+  <h2>Join the Game</h2>
+  <input class="name-input" placeholder="Name" bind:value={name}/>
+  <button on:click={submit}>Join</button>
+  {#if error}
+    <div class="error">{error}</div>
+  {/if}
+</section>
+
+<style>
+  .join { text-align:center }
+  .name-input { padding:0.5rem; margin-top:0.5rem }
+  .error { color:red; margin-top:0.5rem }
+  button { margin-top:0.5rem }
+</style>

--- a/svelte/src/components/LieInput.svelte
+++ b/svelte/src/components/LieInput.svelte
@@ -1,0 +1,18 @@
+<script>
+  export let onSubmit = () => {}
+  export let onAuto = () => {}
+  let lie = ''
+  const submit = () => { onSubmit(lie); lie = '' }
+</script>
+
+<section class="lie-input">
+  <input class="lie-field" placeholder="Your lie" bind:value={lie}/>
+  <button on:click={submit}>Submit</button>
+  <button on:click={onAuto}>Lie for Me</button>
+</section>
+
+<style>
+  .lie-input { display:flex; flex-direction:column; gap:0.5rem; align-items:center }
+  .lie-field { padding:0.5rem; width:100% }
+  button { padding:0.5rem 1rem }
+</style>

--- a/svelte/src/components/OptionButtons.svelte
+++ b/svelte/src/components/OptionButtons.svelte
@@ -1,0 +1,19 @@
+<script>
+  export let options = []
+  export let onSelect = () => {}
+</script>
+
+<section class="option-buttons">
+  <h3>Select the Truth</h3>
+  <ul>
+    {#each options as o}
+      <li><button on:click={() => onSelect(o.id)}>{o.text}</button></li>
+    {/each}
+  </ul>
+</section>
+
+<style>
+  ul { list-style:none; padding:0 }
+  li { margin:0.25rem 0 }
+  button { padding:0.5rem 1rem; width:100% }
+</style>

--- a/svelte/src/constants.js
+++ b/svelte/src/constants.js
@@ -1,0 +1,43 @@
+export const GAME_STATES = {
+  LOBBY: 'lobby',
+  CATEGORY_SELECTION: 'category_selection',
+  QUESTION_READING: 'question_reading',
+  LIE_SUBMISSION: 'lie_submission',
+  OPTION_SELECTION: 'option_selection',
+  TRUTH_REVEAL: 'truth_reveal',
+  SCOREBOARD: 'scoreboard',
+  GAME_ENDED: 'game_ended'
+}
+
+export const SOCKET_EVENTS = {
+  JOIN_GAME: 'join_game',
+  LEAVE_GAME: 'leave_game',
+  START_GAME: 'start_game',
+  SELECT_CATEGORY: 'select_category',
+  SUBMIT_LIE: 'submit_lie',
+  AUTO_LIE: 'auto_lie',
+  SELECT_OPTION: 'select_option',
+  LIKE_LIE: 'like_lie',
+  UPDATE_AVATAR: 'update_avatar',
+  UPDATE_NAME: 'update_name',
+  REQUEST_GAME_STATE: 'request_game_state',
+  CHANGE_QUESTION_PACK: 'change_question_pack',
+  PLAYER_JOINED: 'player_joined',
+  PLAYER_LEFT: 'player_left',
+  PLAYER_RECONNECTED: 'player_reconnected',
+  GAME_STATE_UPDATE: 'game_state_update',
+  GAME_STARTED: 'game_started',
+  CATEGORY_SELECTION_START: 'category_selection_start',
+  QUESTION_READING_START: 'question_reading_start',
+  LIE_SUBMISSION_START: 'lie_submission_start',
+  OPTION_SELECTION_START: 'option_selection_start',
+  TRUTH_REVEAL_START: 'truth_reveal_start',
+  SCOREBOARD_UPDATE: 'scoreboard_update',
+  GAME_ENDED: 'game_ended',
+  ERROR: 'error',
+  TIMER_UPDATE: 'timer_update',
+  PLAYER_AVATAR_UPDATED: 'player_avatar_updated',
+  PLAYER_NAME_UPDATED: 'player_name_updated',
+  HOST_SUB_STEP_INFO: 'host_sub_step_info',
+  AVAILABLE_QUESTION_PACKS: 'available_question_packs'
+}


### PR DESCRIPTION
## Summary
- build constants for the frontend
- implement player flow in `Player.svelte`
- add small components for joining, category selection, lying, and option votes

## Testing Done
- `npm start` *(fails: cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684f4938a95c833096e471c86fed9535