### PR TITLE
Document logging conventions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ The Lie Ability Game is a real-time multiplayer party game where players create 
 - **[Frontend Components](./frontend-components.md)** - Svelte components and UI structure
 - **[Voting & Scoring System](./voting-scoring.md)** - Detailed scoring mechanics and like system
 - **[Development Guide](./development-guide.md)** - Setup, debugging, and troubleshooting
+- **[Logging Conventions](./development-guide.md#logging-conventions)** - Standard console output format
 
 ## Quick Start
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -572,6 +572,25 @@ fix(ui): resolve scoreboard display issue
 docs(api): update socket event documentation
 ```
 
+### Logging Conventions
+
+Use a consistent logging format to improve debugging and traceability. Each log
+message includes an emoji and a category tag:
+
+```javascript
+console.log(`🎯 [PLAYER ACTION] ${playerName} selected category ${categoryId}`);
+console.log(`🎮 [GAME STATE] Game started: Round ${round}, Question ${question}`);
+console.log(`⏰ [TIMER] Category selection timer expired - auto-selecting`);
+console.log(`🏆 [SCORING] ${playerName} fooled ${count} players (+${points} points)`);
+```
+
+**Log Categories:**
+- `[PLAYER ACTION]` - User interactions (join, submit lie, vote, etc.)
+- `[GAME STATE]` - State transitions and game flow
+- `[TIMER]` - Timer events and automatic progressions
+- `[SCORING]` - Point calculations and awards
+- `[CONNECTION]` - Socket connect/disconnect events
+
 ### Pull Request Process
 
 1. **Feature Branch**: Create from `main`


### PR DESCRIPTION
## Summary
- document standard logging format in development guide
- reference logging conventions from main docs index

## Testing
- `npm test -- --passWithNoTests`
- `npm start` *(briefly to ensure startup)*

------
https://chatgpt.com/codex/tasks/task_e_6851881487f4833082d63d6631e045e1