### PR TITLE
test: add integration test and setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,9 +79,11 @@ console.log(`🏆 [SCORING] ${playerName} fooled ${count} players (+${points} po
 ### Development Setup
 ```bash
 npm install          # Install dependencies
+./dev-reqs.sh        # Install testing dependencies
 npm run dev          # Start with nodemon (auto-restart)
 npm start           # Production start
 ```
+When adding new test dependencies, update **dev-reqs.sh** so contributors can install them easily.
 
 ### Testing Approach
 **Primary Testing:** Use the debug interface at `http://localhost:3000/tests/debug-interface.html`

--- a/dev-reqs.sh
+++ b/dev-reqs.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Install all dependencies required to run backend and frontend tests
+set -e
+
+echo "Installing backend dependencies..."
+npm install
+
+echo "Installing frontend dependencies..."
+cd svelte
+npm install
+cd ..
+
+echo "All test dependencies installed."

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -24,6 +24,9 @@ npm install
 cd svelte
 npm install
 cd ..
+
+# Or simply run the helper script
+./dev-reqs.sh
 ```
 
 **2. Environment Configuration**:

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testPathIgnorePatterns: ['<rootDir>/svelte/']
+};

--- a/tests/integration/gameFlow.test.js
+++ b/tests/integration/gameFlow.test.js
@@ -1,0 +1,58 @@
+const Game = require('../../src/models/Game');
+const { GAME_STATES } = require('../../src/utils/constants');
+
+describe('Integration - Complete Game Flow', () => {
+  let game;
+  const mockIo = { to: jest.fn().mockReturnThis(), emit: jest.fn() };
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    game = new Game(mockIo);
+    await game.init();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('should play through a full question cycle with two players', () => {
+    const { player: p1 } = game.addPlayer('Alice', 'socket1');
+    const { player: p2 } = game.addPlayer('Bob', 'socket2');
+
+    const start = game.startGame();
+    expect(start.success).toBe(true);
+    expect(game.state).toBe(GAME_STATES.CATEGORY_SELECTION);
+
+    // Select a category
+    const selector = game.players.get(game.categorySelector);
+    const categoryId = game.categoryOptions[0].id;
+    game.selectCategory(selector.id, categoryId);
+    expect(game.state).toBe(GAME_STATES.QUESTION_READING);
+
+    // Advance to lie submission
+    jest.runOnlyPendingTimers();
+    expect(game.state).toBe(GAME_STATES.LIE_SUBMISSION);
+
+    game.submitLie(p1.id, 'First lie');
+    game.submitLie(p2.id, 'Second lie');
+
+    expect(game.state).toBe(GAME_STATES.OPTION_SELECTION);
+
+    const optionForP1 = game.getSubStepInfo(p1.id).options[0];
+    const optionForP2 = game.getSubStepInfo(p2.id).options[0];
+
+    game.selectOption(p1.id, optionForP1.id);
+    game.selectOption(p2.id, optionForP2.id);
+
+    expect(game.state).toBe(GAME_STATES.TRUTH_REVEAL);
+
+    // Move to scoreboard
+    jest.runOnlyPendingTimers();
+    expect(game.state).toBe(GAME_STATES.SCOREBOARD);
+
+    // Advance to next question (start of new round)
+    jest.runOnlyPendingTimers();
+    expect(game.state).toBe(GAME_STATES.CATEGORY_SELECTION);
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test covering one complete question flow
- add helper script `dev-reqs.sh` to install all test dependencies
- exclude Svelte tests from Jest
- document usage of `dev-reqs.sh` in AGENTS.md and development guide

## Testing
- `npx jest --runInBand`
- `npm test` in `svelte/` *(fails: vitest missing)*

------
https://chatgpt.com/codex/tasks/task_e_68519192247483309ccbca7a48a778a0